### PR TITLE
fixing the multi-instance placeholder list bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -180,6 +180,7 @@ class NestedSort {
     this.removeClassFromEl(this.targetedNode, this.classNames.targeted)
     this.cleanupPlaceholderLists();
     this.draggedNode = null
+    this.targetedNode = null
   }
 
   onDrop(e) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -377,6 +377,28 @@ describe('NestedSort', () => {
 
         expect(ns.draggedNode).toBeNull()
       })
+
+      it('should set the targetedNode property to null', () => {
+        const ns = new NestedSort({
+          data: [
+            { id: 1, text: 'One' },
+            { id: 2, text: 'Two' },
+          ],
+          el: `#${dynamicListWrapperId}`,
+        })
+
+        ns.draggedNode = document.querySelector('[data-id="1"]')
+        ns.targetedNode = document.querySelector('[data-id="2"]')
+        const stopPropagation = jest.fn()
+
+        ns.draggedNode.dispatchEvent(
+          createEvent('dragend', {
+            stopPropagation,
+          })
+        )
+
+        expect(ns.targetedNode).toBeNull()
+      })
     })
 
     describe('drop event', () => {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -366,9 +366,10 @@ describe('NestedSort', () => {
           el: `#${dynamicListWrapperId}`,
         })
 
-        const item = document.querySelector('[data-id="1"]')
+        ns.draggedNode = document.querySelector('[data-id="1"]')
         const stopPropagation = jest.fn()
-        item.dispatchEvent(
+
+        ns.draggedNode.dispatchEvent(
           createEvent('dragend', {
             stopPropagation,
           })


### PR DESCRIPTION
The bug concerned all the lists on a multi-instance page which has had interactions before. In this case, when we dragged an item on a list in a way which caused an empty placeholder list being created on that list, a new empty placeholder list was created on every single list which has had interactions before (inside their last targetedNode) just because we did not reset the targetedNode after a drag finished.

@ptibbetts when you have a bit of time, please.